### PR TITLE
Putting V8 in imports allows apps to build on shinyapps.io 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,10 +14,10 @@ URL: https://github.com/daattali/shinyjs
 Depends: R (>= 3.1.0)
 Imports:
     shiny (>= 0.11.1)
+    V8 (>= 0.6)
 Suggests:
     knitr (>= 1.7),
-    testthat (>= 0.9.1),
-    V8 (>= 0.6)
+    testthat (>= 0.9.1)
 License: MIT + file LICENSE
 LazyData: true
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Description: Perform common JavaScript operations in Shiny
 URL: https://github.com/daattali/shinyjs
 Depends: R (>= 3.1.0)
 Imports:
-    shiny (>= 0.11.1)
+    shiny (>= 0.11.1),
     V8 (>= 0.6)
 Suggests:
     knitr (>= 1.7),


### PR DESCRIPTION
I tried to deploy an app to shinyapps.io using extendShinyjs(), but it didn't build V8. Moving it from suggests to imports made it work, but not sure if this is more generally desired. 