### PR TITLE
Use container based builds with package caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: r
+sudo: false
+cache: packages
 
-# R support in Travis CI currently requires sudo http://docs.travis-ci.com/user/languages/r/
-sudo: true
-
-apt_packages:
- - libv8-dev
+addons:
+ apt:
+  packages:
+    - libv8-dev


### PR DESCRIPTION
Using container based builds is suggested going forward. There is a higher queue so they start up much faster and can use package caching for your dependencies so subsequent builds are faster. It also relies on fewer apt packages which should reduce the apt failures you were seeing.

See https://docs.travis-ci.com/user/languages/r for updated documentation on the recent changes.

Sorry for your frustrations with R travis, hopefully you will find your Travis builds to be more stable going forward.