### PR TITLE
Whitelisting mouse wheel functions, fixing clienty typo

### DIFF
--- a/inst/srcjs/shinyjs-default-funcs.js
+++ b/inst/srcjs/shinyjs-default-funcs.js
@@ -447,9 +447,9 @@ shinyjs = function() {
 
       el[params.event](function(event) {
         // Store a subset of the event properties (many are non-serializeable)
-        var props = ['altKey', 'button', 'buttons', 'clientX', 'clienty',
+        var props = ['altKey', 'button', 'buttons', 'clientX', 'clientY',
           'ctrlKey', 'pageX', 'pageY', 'screenX', 'screenY', 'shiftKey',
-          'which', 'charCode', 'key', 'keyCode'];
+          'which', 'charCode', 'key', 'keyCode', 'deltaX', 'deltaY', 'deltaFactor'];
         var eventSimple = {};
         $.each(props, function(idx, prop) {
           if (prop in event) {


### PR DESCRIPTION
white-listing deltaX, Y and Factor from https://github.com/jquery/jquery-mousewheel, https://github.com/daattali/shinyjs/issues/159

changing clienty to clientY so it comes through correctly

```
$deltaX
[1] 0
$deltaY
[1] 1
$deltaFactor
[1] 1
$altKey
[1] FALSE
$button
[1] 0
$clientX
[1] 348
$clientY
[1] 266
$ctrlKey
[1] FALSE
$pageX
[1] 348
$pageY
[1] 266
$screenX
[1] 828
$screenY
[1] 333
$shiftKey
[1] FALSE
```