### PR TITLE
In runCode, capture printed expression output for rendering (if desired).

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,7 @@ Suggests:
     knitr (>= 1.7),
     rmarkdown,
     shinyAce,
+    stringi,
     testthat (>= 0.9.1),
     V8 (>= 0.6)
 License: AGPL-3

--- a/R/runcode.R
+++ b/R/runcode.R
@@ -37,7 +37,10 @@
 #'   shinyApp(
 #'     ui = fluidPage(
 #'       useShinyjs(),  # Set up shinyjs
-#'       runcodeUI(code = "shinyjs::alert('Hello!')")
+#'       runcodeUI(code = "shinyjs::alert('Hello!')"),
+#'       shiny::tags$br(),
+#'       shiny::tags$label("Output:"),
+#'       textOutput("runcode_output", container=pre)
 #'     ),
 #'     server = function(input, output) {
 #'       runcodeServer()
@@ -106,7 +109,8 @@ runcodeServer <- function() {
 
     tryCatch(
       shiny::isolate(
-        eval(parse(text = session$input[['runcode_expr']]), envir = parentFrame)
+        session$output$runcode_output <- renderText(paste0(eval(parse(text = session$input[['runcode_expr']]),
+                                             envir = parentFrame), collapse="\n"))
       ),
       error = function(err) {
         shinyjs::html("runcode_errorMsg", as.character(err$message))

--- a/R/runcode.R
+++ b/R/runcode.R
@@ -36,6 +36,7 @@
 #'
 #'   shinyApp(
 #'     ui = fluidPage(
+#'       shiny::tags$label("R code to execute:"),
 #'       useShinyjs(),  # Set up shinyjs
 #'       runcodeUI(code = "shinyjs::alert('Hello!')"),
 #'       shiny::tags$br(),

--- a/R/runcode.R
+++ b/R/runcode.R
@@ -109,8 +109,12 @@ runcodeServer <- function() {
 
     tryCatch(
       shiny::isolate(
-        session$output$runcode_output <- renderText(paste0(eval(parse(text = session$input[['runcode_expr']]),
-                                             envir = parentFrame), collapse="\n"))
+        session$output$runcode_output <- renderText(
+          paste0(capture.output(
+            eval(parse(text = session$input[['runcode_expr']]),
+                 envir = parentFrame)
+            ),
+            collapse="\n"))
       ),
       error = function(err) {
         shinyjs::html("runcode_errorMsg", as.character(err$message))

--- a/R/runcode.R
+++ b/R/runcode.R
@@ -157,13 +157,16 @@ runcodeServer <- function(show_output=FALSE, preprocessor=NULL) {
         if(is.function(preprocessor))
           expr_text <- preprocessor(expr_text)
 
+        expr_conn <- textConnection(expr_text)
+
         output <- paste0(
-          capture.output(
-            do.call(withAutoprint,
-                    list(parse(text=expr_text)),
-                    envir=parentFrame)
-          ),
-          collapse="\n")
+            capture.output(
+              do.call(source,
+                      args=list(file=expr_conn, echo=TRUE),
+                      envir=parentFrame)
+            ),
+            collapse="\n"
+        )
 
         if(show_output)
           session$output$runcode_output <- renderText(output)

--- a/R/runcode.R
+++ b/R/runcode.R
@@ -112,8 +112,7 @@ runcodeServer <- function() {
       shiny::isolate(
         session$output$runcode_output <- renderText(
           paste0(capture.output(
-            eval(parse(text = session$input[['runcode_expr']]),
-                 envir = parentFrame)
+            do.call(withAutoprint, list(parse(text=session$input[['runcode_expr']])))
             ),
             collapse="\n"))
       ),

--- a/R/useShinyjs.R
+++ b/R/useShinyjs.R
@@ -19,8 +19,7 @@
 #' how to use shinyjs in these apps.
 #' @param showLog Deprecated.
 #' @return Scripts that \code{shinyjs} requires that are automatically inserted
-#' to the app's \code{<head>} tag. In order for the scripts to be inserted
-#' correctly, 
+#' to the app's \code{<head>} tag.
 #' @examples
 #' if (interactive()) {
 #'   library(shiny)

--- a/man/runcode.Rd
+++ b/man/runcode.Rd
@@ -9,7 +9,7 @@
 runcodeUI(code = "", type = c("text", "textarea", "ace"), width = NULL,
   height = NULL, includeShinyjs = FALSE)
 
-runcodeServer()
+runcodeServer(show_output = FALSE, preprocessor = NULL)
 }
 \arguments{
 \item{code}{The initial R code to show in the text input when the app loads}
@@ -30,6 +30,13 @@ Use of the \code{"ace"} option requires the \code{shinyAce} package.}
 \item{includeShinyjs}{Set this to \code{TRUE} only if your app does not have
 a call to \code{useShinyjs()}. If you are already calling \code{useShinyjs()}
 in your app, do not use this parameter.}
+
+\item{show_output}{If \code{TRUE} the results of executing the R code will be
+placed into \code{output$runcode_output} using \code{shiny::renderText} to
+allow display via adding \code{textOutput("runcode_output", container=pre)}.}
+
+\item{preprocessor}{Function accepting a single vector argument, which will
+be called on the user-provided R code before evaluating it.}
 }
 \description{
 Sometimes when developing a Shiny app, it's useful to be able to run some R
@@ -43,12 +50,27 @@ To use this construct, you must add a call to \code{runcodeUI()} in the UI
 of your app, and a call to \code{runcodeServer()} in the server function. You
 also need to initialize shinyjs with a call to \code{useShinyjs()} in the UI.
 }
+\details{
+If a function is provided to the \code{preprocss} argument of
+\code{runcodeServer}, this will be called on the user-provided R code before
+evaluating it.  This allows, for instance, conversion of non-ASCII open and
+closing quote characters (unhelpfully) created by some browsers to standard
+ASCII quote characters (see the second example).
+
+If \code{show_output=TRUE}, the results of executing the R code will be
+placed into \code{output$runcode_output} using \code{shiny::renderText} to
+allow you to display this, if desired, by adding
+\code{textOutput("runcode_output", container=pre)} to the UI of your
+app (see the second example).
+}
 \note{
 You can only have one \code{runcode} construct in your shiny app.
 Calling this function multiple times within the same app will result in
 unpredictable behaviour.
 }
 \examples{
+
+# One-line of code, no display of output
 if (interactive()) {
   library(shiny)
 
@@ -59,6 +81,32 @@ if (interactive()) {
     ),
     server = function(input, output) {
       runcodeServer()
+    }
+  )
+}
+
+# Muti-line code - pre-process input to convert non-ASCII character to ASCII
+# and then display output as if entered on the console
+if (interactive()) {
+  library(shiny)
+  library(stringi)
+
+  to_ascii <- function(x) stri_trans_general(x, "Any-Latin; Latin-ASCII")
+
+  shinyApp(
+    ui = fluidPage(
+      shiny::tags$label("R code to execute:"),
+      useShinyjs(),  # Set up shinyjs
+      runcodeUI(code = "shinyjs::alert('Hello!')\\nx <- rnorm(10)\\nstem(x)",
+                type = "textarea",
+                height="10em",
+                width="80em"),
+      shiny::tags$br(),
+      shiny::tags$label("Output:"),
+      textOutput("runcode_output", container=pre)
+    ),
+    server = function(input, output) {
+      runcodeServer(show_output=TRUE, preprocess=to_ascii)
     }
   )
 }

--- a/man/useShinyjs.Rd
+++ b/man/useShinyjs.Rd
@@ -31,7 +31,8 @@ to the app's \code{<head>} tag.
 \description{
 This function must be called from a Shiny app's UI in order for all other
 \code{shinyjs} functions to work.\cr\cr
-You can call \code{useShinyjs()} from anywhere inside the UI.
+You can call \code{useShinyjs()} from anywhere inside the UI, as long as the
+final app UI contains the result of \code{useShinyjs()}.
 }
 \examples{
 if (interactive()) {


### PR DESCRIPTION
I often want to see output from the R commands evaluated in `runCode`.    With this change, the following code (captured in the roxygen documentation) now works properly:
```
  shinyApp(
    ui = fluidPage(
      useShinyjs(),  # Set up shinyjs
      runcodeUI(code = "shinyjs::alert('Hello!')"),
      shiny::tags$br(),
      shiny::tags$label("Output:"),
      textOutput("runcode_output", container=pre)
    ),
    server = function(input, output) {
      runcodeServer()
    }
  )
```

For example:
![image](https://user-images.githubusercontent.com/22243578/42717493-658e84ce-86cf-11e8-8aa0-26099a3a52c4.png)
