### PR TITLE
Improve performance of handling onevent for dynamic elements.

### DIFF
--- a/inst/srcjs/shinyjs-default-funcs.js
+++ b/inst/srcjs/shinyjs-default-funcs.js
@@ -404,29 +404,34 @@ shinyjs = function() {
     // just created. If so, find out what events were registered to it and the
     // shiny event handlers for it, and attach them
     _mutationSubscribers.push(function(node) {
+      // check the top node
       $node = $(node);
-      $.each(_oneventData, function(id) {
-        var elementData = null;
-        if ($node.attr("id") == id) {
-          elementData = _oneventData[id];
-        } else if ($node.find("#" + id).length > 0) {
-          elementData = _oneventData[id];
-        }
-        if (elementData !== null) {
-          $.each(elementData, function(event, eventDatas) {
-            $.each(eventDatas, function(idx, eventData) {
-              _oneventAttach({
-                event        : event,
-                id           : id,
-                shinyInputId : eventData.shinyInputId,
-                add          : true,
-                customProps  : eventData.customProps
-              });
-            });
-          });
-        }
+      var id = $node.attr("id");
+      _eventsAttachById(id);
+      // check all descendants
+      $node.find("*").each(function() {
+        var id = $(this).attr("id");
+        _eventsAttachById(id);
       });
     });
+  };
+
+  // Attach all events registered for a given id (if any)
+  var _eventsAttachById = function(id) {
+    var elementData = _oneventData[id];
+    if (elementData !== null) {
+      $.each(elementData, function(event, eventDatas) {
+        $.each(eventDatas, function(idx, eventData) {
+          _oneventAttach({
+            event        : event,
+            id           : id,
+            shinyInputId : eventData.shinyInputId,
+            add          : true,
+            customProps  : eventData.customProps
+          });
+        });
+      });
+    }
   };
 
   // attach an event listener to a DOM element that will trigger a call to Shiny

--- a/inst/srcjs/shinyjs-default-funcs.js
+++ b/inst/srcjs/shinyjs-default-funcs.js
@@ -405,7 +405,7 @@ shinyjs = function() {
     // shiny event handlers for it, and attach them
     _mutationSubscribers.push(function(node) {
       // check the top node
-      $node = $(node);
+      var $node = $(node);
       var id = $node.attr("id");
       _eventsAttachById(id);
       // check all descendants


### PR DESCRIPTION
The `_initOnevent()` JavaScript function ensures `onevent()` works for dynamic elements. It basically checks if any added element has registered events and attaches them. The current implementation suffers from cases where there are many registered events and many elements added all at once, which is not uncommon e.g. with leaflet maps rendering many polygons.

The code at below reproduces this behavior in a simple Shiny app rendering a map. One can dynamically add registered `onclick()` events on increasingly more buttons and see how showing the map is more and more delayed. For the 1000 polygons examples, this should be clearly noticeable already with 50-100 added buttons. Note that the actual rendering of the map is fast (tracked by a spinner), but after that the app is stuck for some time before the map is actually painted. This delay is spent in the long, repeated execution of `_initOnevent()` (the profiler of Firefox or Chrome reveals this).

```r
library(shiny)
library(leaflet)
`%>%` <- magrittr::`%>%`
# leaflet map with dummy set of polygons ----
n_ex <- 1000
set.seed(12538)
data <- data.frame(y = runif(n_ex, 42, 50), x = runif(n_ex, 7, 14),
                   z = seq(0, 1, length.out = n_ex))
# we love hexagons
hex <- seq(0, 2, length.out = 7) - 1/6
HexPolygons <- function(i) {
  sp::Polygons(ID = i, list(
    sp::Polygon(cbind(data$x[i] + 0.1*cospi(hex), data$y[i] + 0.1*sinpi(hex)))
  ))
}
map_data <- sp::SpatialPolygonsDataFrame(
  data = data,
  sp::SpatialPolygons(lapply(seq_len(nrow(data)), HexPolygons))
)
.col <- colorNumeric(rainbow(256), NULL)
map <- leaflet(map_data) %>% addTiles() %>% addPolygons(color = ~.col(z))
# shiny app ----
shinyApp(
  ui = fluidPage(
    shinyjs::useShinyjs(),
    verticalLayout(
      h4("Slow handling of onclick() events for items not created yet"),
      actionButton("draw", "draw map"),
      shinycssloaders::withSpinner(leafletOutput("map")),
      div("Add more buttons and re-draw the map:",
          "the more you have added, the slowest it is"),
      actionButton("add", "add 10 buttons")
    )
  ),
  server = function(input, output, session) {
    ibtn <- 0
    output$map <- NULL
    observeEvent(input$draw, output$map <- renderLeaflet(map))
    observeEvent(input$add, {
      new_btns <- paste0("btn", ibtn + seq_len(10))
      ibtn <<- ibtn + 10
      # wrap new buttons in a div to check events for children are attached
      newUI <- div(mapply(SIMPLIFY = FALSE, actionButton, new_btns, new_btns))
      # swap the two lines below and the slow behavior is gone!!
      lapply(new_btns, function(id) shinyjs::onclick(id, message("click ", id)))
      insertUI(ui = newUI, "#add", "afterEnd", immediate = TRUE)
    })
  }
)

```

I have re-factored `_initOnevent()` to avoid looping over the registered events and for each of them going through the new elements. With this approach we are going through each new top node and its descendants (with `$node.find("*")`) only once, as opposed to going through them (with `$node.find("#" + id)`) for each registered elements. This has also the nice property of having an execution time that depends only on the complexity of the added elements.

The added computation cost might be uniquely in the check on existing `_oneventData[id]` for each node and descendants, although jQuery is probably doing something similar with `$node.find("#" + id)`.

I could not think of cases where this approach could be considerably slower, but it is absolutely a killer for the cases exemplified below, which can be assessed by running the example after installing from the fork via `remotes::install_github("riccardoporreca/shinyjs", "performance-initOnevent")`

**Disclaimer**: My JavaScript skills are a bit rusty, so there might be better ways to implement this different approach, which conceptually and practically seems desirable to implement.
